### PR TITLE
Add MyMapComponent and connect up redux.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,28 +1,42 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { showMarkerAction } from './actions/showMarkerAction'
+import {MyMapComponent} from './components/myMapComponent'
+
 import logo from './logo.svg';
 import './App.css';
 
+const mapStateToProps = state => ({
+  ...state
+});
+
+const mapDispatchToProps = dispatch => ({
+  showMarker: (isMarkerShown) => dispatch(showMarkerAction(isMarkerShown))
+});
+
 class App extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+    this.toggleMarker = this.toggleMarker.bind(this);
+  }
+
   render() {
     return (
       <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <p>
-            Edit <code>src/App.js</code> and save to reload.
-          </p>
-          <a
-            className="App-link"
-            href="https://reactjs.org"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn React
-          </a>
-        </header>
+        <MyMapComponent
+          isMarkerShown={this.props.mapMarker.isMarkerShown}
+          onMarkerClick={this.toggleMarker}
+        />
+        <button onClick={this.toggleMarker} >Toggle Map Marker</button>
       </div>
     );
   }
+
+  toggleMarker = (event) => {
+    this.props.showMarker(!this.props.mapMarker.isMarkerShown);
+  };
+
 }
 
-export default App;
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/actions/showMarkerAction.js
+++ b/src/actions/showMarkerAction.js
@@ -1,0 +1,3 @@
+export const showMarkerAction = (isMarkerShown) => {
+  return {  type: 'SHOW_MARKER',  isMarkerShown: isMarkerShown };
+};

--- a/src/components/myMapComponent.js
+++ b/src/components/myMapComponent.js
@@ -1,0 +1,24 @@
+import React from "react"
+import { compose, withProps } from "recompose"
+import {GoogleMap, Marker, withGoogleMap, withScriptjs} from "react-google-maps";
+
+// IMPORTANT ! https://developers.google.com/maps/documentation/javascript/get-api-key
+const apiKey = '';
+
+export const MyMapComponent = compose(
+  withProps({
+    googleMapURL: `https://maps.googleapis.com/maps/api/js?v=3.exp&key=${apiKey}&libraries=geometry,drawing,places`,
+    loadingElement: <div style={{ height: `100%` }} />,
+    containerElement: <div style={{ height: `90vh` }} />,
+    mapElement: <div style={{ height: `90%` }} />,
+  }),
+  withScriptjs,
+  withGoogleMap
+)((props) =>
+  <GoogleMap
+    defaultZoom={8}
+    defaultCenter={{ lat: -34.397, lng: 150.644 }}
+  >
+    {props.isMarkerShown && <Marker position={{ lat: -34.397, lng: 150.644 }} onClick={props.onMarkerClick} />}
+  </GoogleMap>
+);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux'
+import configureStore from './store';
+
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<Provider store={configureStore()}>
+  <App />
+</Provider>, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/reducers/mapMarkerReducer.js
+++ b/src/reducers/mapMarkerReducer.js
@@ -1,0 +1,11 @@
+export default (state = { isMarkerShown: true}, action) => {
+
+  switch (action.type) {
+    case 'SHOW_MARKER':
+      return  {
+        isMarkerShown: action.isMarkerShown
+    };
+    default:
+      return state
+  }
+}

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -1,0 +1,5 @@
+import { combineReducers } from 'redux';
+import mapMarker from './mapMarkerReducer';
+export default combineReducers({
+  mapMarker
+});

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,9 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import rootReducer from './reducers/rootReducer';
+export default function configureStore(initialState={}) {
+  return createStore(
+    rootReducer,
+    applyMiddleware(thunk)
+  );
+}


### PR DESCRIPTION
Add MyMapComponent and redux boilerplate for related store, reducers, and actions for mapMarker. 
Update App.js to use MyMapComponent and connect up redux with mapMarker props and actions.

1 - Everything inside a component will be mounted automatically on the map
2 - You need to wrap the component with withGoogleMap HOC in order to initialize dom instances.
3 - To load Google Maps JavaScript API v3 you need to wrap with withScriptjs HOC.
4 - withGoogleMap  requires containerElement: ReactElement - AND - mapElement: ReactElement
5 - withScriptjs requires googleMapURL:String  - AND - loadingElement: ReactElement

There are lots of other HOCs you can add to it. They are well documented at.
(See https://tomchentw.github.io/react-google-maps/#usage--configuration) 